### PR TITLE
Feat/18 feat 로그인

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,11 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.security:spring-security-test'
 
+	// jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
 	// email
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 

--- a/src/main/java/umc/demoday/whatisthis/domain/member/controller/MemberAuthController.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/member/controller/MemberAuthController.java
@@ -1,0 +1,30 @@
+package umc.demoday.whatisthis.domain.member.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import umc.demoday.whatisthis.domain.member.dto.login.LoginReqDTO;
+import umc.demoday.whatisthis.domain.member.dto.login.LoginResDTO;
+import umc.demoday.whatisthis.domain.member.service.member.MemberAuthService;
+import umc.demoday.whatisthis.global.apiPayload.CustomResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/members")
+public class MemberAuthController {
+
+    private final MemberAuthService memberAuthService;
+
+    @PostMapping("/login")
+    @Operation(summary = "일반 사용자 로그인 API -by 이정준")
+    public CustomResponse<LoginResDTO> login(
+            @RequestBody @Valid LoginReqDTO request
+    ) {
+        LoginResDTO response = memberAuthService.login(request);
+        return CustomResponse.ok(response);
+    }
+}

--- a/src/main/java/umc/demoday/whatisthis/domain/member/dto/login/LoginReqDTO.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/member/dto/login/LoginReqDTO.java
@@ -1,0 +1,12 @@
+package umc.demoday.whatisthis.domain.member.dto.login;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginReqDTO {
+
+    private String username;
+    private String password;
+}

--- a/src/main/java/umc/demoday/whatisthis/domain/member/dto/login/LoginResDTO.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/member/dto/login/LoginResDTO.java
@@ -1,0 +1,10 @@
+package umc.demoday.whatisthis.domain.member.dto.login;
+
+import lombok.Getter;
+
+@Getter
+public class LoginResDTO {
+
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/umc/demoday/whatisthis/domain/member/dto/login/LoginResDTO.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/member/dto/login/LoginResDTO.java
@@ -1,8 +1,10 @@
 package umc.demoday.whatisthis.domain.member.dto.login;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class LoginResDTO {
 
     private String accessToken;

--- a/src/main/java/umc/demoday/whatisthis/domain/member/repository/MemberRepository.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/member/repository/MemberRepository.java
@@ -5,7 +5,7 @@ import umc.demoday.whatisthis.domain.member.Member;
 
 import java.util.Optional;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Integer> {
 
     boolean existsByNickname(String nickname);
 

--- a/src/main/java/umc/demoday/whatisthis/domain/member/repository/MemberRepository.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/member/repository/MemberRepository.java
@@ -3,9 +3,13 @@ package umc.demoday.whatisthis.domain.member.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import umc.demoday.whatisthis.domain.member.Member;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByNickname(String nickname);
 
     boolean existsByMemberId(String memberId);
+
+    Optional<Member> findByMemberId(String memberId);
 }

--- a/src/main/java/umc/demoday/whatisthis/domain/member/service/member/MemberAuthService.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/member/service/member/MemberAuthService.java
@@ -1,0 +1,8 @@
+package umc.demoday.whatisthis.domain.member.service.member;
+
+import umc.demoday.whatisthis.domain.member.dto.login.LoginReqDTO;
+import umc.demoday.whatisthis.domain.member.dto.login.LoginResDTO;
+
+public interface MemberAuthService {
+    LoginResDTO login(LoginReqDTO request);
+}

--- a/src/main/java/umc/demoday/whatisthis/domain/member/service/member/MemberAuthService.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/member/service/member/MemberAuthService.java
@@ -5,4 +5,6 @@ import umc.demoday.whatisthis.domain.member.dto.login.LoginResDTO;
 
 public interface MemberAuthService {
     LoginResDTO login(LoginReqDTO request);
+    LoginResDTO reissue(String refreshToken);
+
 }

--- a/src/main/java/umc/demoday/whatisthis/domain/member/service/member/MemberAuthServiceImpl.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/member/service/member/MemberAuthServiceImpl.java
@@ -7,8 +7,11 @@ import umc.demoday.whatisthis.domain.member.Member;
 import umc.demoday.whatisthis.domain.member.dto.login.LoginReqDTO;
 import umc.demoday.whatisthis.domain.member.dto.login.LoginResDTO;
 import umc.demoday.whatisthis.domain.member.repository.MemberRepository;
+import umc.demoday.whatisthis.domain.refresh_token.RefreshToken;
+import umc.demoday.whatisthis.domain.refresh_token.repository.RefreshTokenRepository;
 import umc.demoday.whatisthis.global.apiPayload.code.GeneralErrorCode;
 import umc.demoday.whatisthis.global.apiPayload.exception.GeneralException;
+import umc.demoday.whatisthis.global.security.JwtProvider;
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +20,7 @@ public class MemberAuthServiceImpl implements MemberAuthService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     @Override
     public LoginResDTO login(LoginReqDTO request) {
@@ -29,7 +33,10 @@ public class MemberAuthServiceImpl implements MemberAuthService {
         }
 
         String accessToken = jwtProvider.createAccessToken(member.getId(), "ROLE_USER");
+        String refreshToken = jwtProvider.createRefreshToken(member.getId());
 
-        return new LoginResDTO(accessToken, null);
+        refreshTokenRepository.save(new RefreshToken(member.getId(), refreshToken));
+
+        return new LoginResDTO(accessToken, refreshToken);
     }
 }

--- a/src/main/java/umc/demoday/whatisthis/domain/member/service/member/MemberAuthServiceImpl.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/member/service/member/MemberAuthServiceImpl.java
@@ -1,0 +1,35 @@
+package umc.demoday.whatisthis.domain.member.service.member;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import umc.demoday.whatisthis.domain.member.Member;
+import umc.demoday.whatisthis.domain.member.dto.login.LoginReqDTO;
+import umc.demoday.whatisthis.domain.member.dto.login.LoginResDTO;
+import umc.demoday.whatisthis.domain.member.repository.MemberRepository;
+import umc.demoday.whatisthis.global.apiPayload.code.GeneralErrorCode;
+import umc.demoday.whatisthis.global.apiPayload.exception.GeneralException;
+
+@Service
+@RequiredArgsConstructor
+public class MemberAuthServiceImpl implements MemberAuthService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public LoginResDTO login(LoginReqDTO request) {
+
+        Member member = memberRepository.findByMemberId(request.getUsername())
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.MEMBER_NOT_FOUND));
+
+        if (!passwordEncoder.matches(request.getPassword(), member.getPassword())) {
+            throw new GeneralException(GeneralErrorCode.INVALID_PASSWORD);
+        }
+
+        String accessToken = jwtProvider.createAccessToken(member.getId(), "ROLE_USER");
+
+        return new LoginResDTO(accessToken, null);
+    }
+}

--- a/src/main/java/umc/demoday/whatisthis/domain/refresh_token/RefreshToken.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/refresh_token/RefreshToken.java
@@ -1,0 +1,25 @@
+package umc.demoday.whatisthis.domain.refresh_token;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "refresh_token")
+public class RefreshToken {
+
+    @Id
+    private Integer memberId;
+
+    private String token;
+
+    public void updateToken(String token) {
+        this.token = token;
+    }
+}

--- a/src/main/java/umc/demoday/whatisthis/domain/refresh_token/controller/AuthTokenController.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/refresh_token/controller/AuthTokenController.java
@@ -1,0 +1,24 @@
+package umc.demoday.whatisthis.domain.refresh_token.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import umc.demoday.whatisthis.domain.member.dto.login.LoginResDTO;
+import umc.demoday.whatisthis.domain.member.service.member.MemberAuthService;
+import umc.demoday.whatisthis.global.apiPayload.CustomResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthTokenController {
+
+    private final MemberAuthService memberAuthService;
+
+    @PostMapping("/reissue")
+    public CustomResponse<LoginResDTO> reissue(@RequestHeader("Authorization") String refreshToken) {
+        LoginResDTO response = memberAuthService.reissue(refreshToken);
+        return CustomResponse.ok(response);
+    }
+}

--- a/src/main/java/umc/demoday/whatisthis/domain/refresh_token/controller/AuthTokenController.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/refresh_token/controller/AuthTokenController.java
@@ -1,5 +1,7 @@
 package umc.demoday.whatisthis.domain.refresh_token.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -17,7 +19,8 @@ public class AuthTokenController {
     private final MemberAuthService memberAuthService;
 
     @PostMapping("/reissue")
-    public CustomResponse<LoginResDTO> reissue(@RequestHeader("Authorization") String refreshToken) {
+    @Operation(summary = "accessToken 재발급 API -by 이정준", security = {@SecurityRequirement(name = "")})
+    public CustomResponse<LoginResDTO> reissue(@RequestHeader("Refresh-Token") String refreshToken) {
         LoginResDTO response = memberAuthService.reissue(refreshToken);
         return CustomResponse.ok(response);
     }

--- a/src/main/java/umc/demoday/whatisthis/domain/refresh_token/repository/RefreshTokenRepository.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/refresh_token/repository/RefreshTokenRepository.java
@@ -1,0 +1,8 @@
+package umc.demoday.whatisthis.domain.refresh_token.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.demoday.whatisthis.domain.refresh_token.RefreshToken;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Integer> {
+    boolean existsByMemberId(Integer memberId);
+}

--- a/src/main/java/umc/demoday/whatisthis/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/umc/demoday/whatisthis/global/apiPayload/code/GeneralErrorCode.java
@@ -18,6 +18,9 @@ public enum GeneralErrorCode implements BaseErrorCode {
     // 멤버 관련 에러
     ALREADY_EXIST_MEMBER_ID(HttpStatus.BAD_REQUEST, "MEMBER4001", "이미 사용 중인 아이디입니다."),
     ALREADY_EXIST_NICKNAME(HttpStatus.BAD_REQUEST, "MEMBER4002", "이미 사용 중인 닉네임입니다."),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER4040", "존재하지 않는 회원입니다."),
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "MEMBER4010", "비밀번호가 일치하지 않습니다."),
+
 
     // 이메일 관련 에러
     EMAIL_AUTH_CODE_MISMATCH(HttpStatus.BAD_REQUEST, "EMAIL4000", "인증 코드 번호가 일치하지 않습니다."),

--- a/src/main/java/umc/demoday/whatisthis/global/config/SecurityConfig.java
+++ b/src/main/java/umc/demoday/whatisthis/global/config/SecurityConfig.java
@@ -27,6 +27,7 @@ public class SecurityConfig {
                                 "/members/signup",
                                 "/members/email-auth",
                                 "/members/login",
+                                "/auth/reissue",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/swagger-resources/**",

--- a/src/main/java/umc/demoday/whatisthis/global/config/SecurityConfig.java
+++ b/src/main/java/umc/demoday/whatisthis/global/config/SecurityConfig.java
@@ -6,6 +6,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import umc.demoday.whatisthis.global.security.JwtAuthenticationFilter;
 
 @Configuration
 public class SecurityConfig {
@@ -17,20 +19,22 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtAuthenticationFilter jwtAuthenticationFilter) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(
                                 "/members/signup",
                                 "/members/email-auth",
+                                "/members/login",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/swagger-resources/**",
                                 "/webjars/**"
                         ).permitAll()
                         .anyRequest().authenticated()
-                );
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/umc/demoday/whatisthis/global/config/SwaggerConfig.java
+++ b/src/main/java/umc/demoday/whatisthis/global/config/SwaggerConfig.java
@@ -17,7 +17,6 @@ public class SwaggerConfig {
         Info info = new Info().title("이게뭐예요").description("Umc 8기 Demoday 이게뭐예요 Swagger").version("0.0.1");
 
         String securityScheme = "JWT TOKEN";
-        SecurityRequirement securityRequirement = new SecurityRequirement().addList(securityScheme);
 
         Components components = new Components()
                 .addSecuritySchemes(securityScheme, new SecurityScheme()
@@ -29,7 +28,6 @@ public class SwaggerConfig {
         return new OpenAPI()
                 .info(info)
                 .addServersItem(new Server().url("/"))
-                .addSecurityItem(securityRequirement)
                 .components(components);
     }
 }

--- a/src/main/java/umc/demoday/whatisthis/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/umc/demoday/whatisthis/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,58 @@
+package umc.demoday.whatisthis.global.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import umc.demoday.whatisthis.domain.member.Member;
+import umc.demoday.whatisthis.domain.member.repository.MemberRepository;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+    private final MemberRepository memberRepository;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        // 1. Authorization 헤더에서 Bearer 토큰 추출
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            String token = bearerToken.substring(7);
+
+            // 2. 토큰 유효성 검사
+            if (jwtProvider.validateToken(token)) {
+                Integer memberId = jwtProvider.getUserIdFromToken(token);
+
+                // 3. DB에서 사용자 조회 (기본 정보만 필요하면 생략 가능)
+                Member member = memberRepository.findById(memberId)
+                        .orElse(null);
+
+                if (member != null) {
+                    // 4. 인증 객체 생성
+                    UsernamePasswordAuthenticationToken authentication =
+                            new UsernamePasswordAuthenticationToken(member, null, null);
+
+                    authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+                    // 5. SecurityContext에 등록
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
+            }
+        }
+        // 6. 다음 필터로 넘김
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/umc/demoday/whatisthis/global/security/JwtProvider.java
+++ b/src/main/java/umc/demoday/whatisthis/global/security/JwtProvider.java
@@ -1,0 +1,85 @@
+package umc.demoday.whatisthis.global.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtProvider {
+
+    @Value("${jwt.secret}")
+    private String secretKeyString;
+
+    private Key secretKey;
+
+    private final long ACCESS_TOKEN_VALID_TIME = 1000L * 60 * 30;     // 30분
+    private final long REFRESH_TOKEN_VALID_TIME = 1000L * 60 * 60 * 24 * 7; // 7일
+
+    @PostConstruct
+    protected void init() {
+        this.secretKey = Keys.hmacShaKeyFor(secretKeyString.getBytes());
+    }
+
+    // AccessToken 생성
+    public String createAccessToken(Integer memberId, String role) {
+        Claims claims = Jwts.claims().setSubject(String.valueOf(memberId));
+        claims.put("role", role);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_VALID_TIME))
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    // RefreshToken 생성 (payload 최소화, DB에서 추적)
+    public String createRefreshToken(Integer memberId) {
+        return Jwts.builder()
+                .setSubject(String.valueOf(memberId))
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_VALID_TIME))
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    // 토큰 검증
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    // 토큰에서 사용자 ID 추출
+    public Integer getUserIdFromToken(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        return Integer.parseInt(claims.getSubject());
+    }
+
+    // 토큰에서 Role 추출
+    public String getRoleFromToken(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        return claims.get("role", String.class);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,3 +28,6 @@ spring:
           auth: true
           starttls:
             enable: true
+
+jwt:
+  secret: ${JWT_SECRET}


### PR DESCRIPTION
## PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## 관련 이슈 링크
Close #18 

## 개요
- "일반" 사용자 로그인 API 구현
- accessToken 재발급 API 구현
- JWT 관련 유틸구성
- Spring Security 설정

## 변경 사항 (커밋)

## 스크린샷

## 기타 더 이야기해볼 점
refresh_token 엔티티 새로 추가했습니다. (member랑 1대1 관계)
API 엔드포인트 변경 및 새로 추가했습니다. (일반 사용자 로그인 : /members/login     &    accessToken 재발급 : /auth/reissue)
일반 사용자 로그인으로 로그인한 유저는 ROLE_USER라는 ROLE을 부여했습니다. (나중에 관리자는 ROLE_ADMIN 부여 예정)
일단 회원가입 API 이용해서 Member 엔티티에 데이터 하나 넣어놨습니다. 
그리고 refresh_token DB에도 아마 값이 들어가있을 겁니다. (시간 지나면 없어질 거긴 함. 아마...)
application.yml에 JWT_SECRET 환경변수 입력해야할겁니다.

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
