### PR TITLE
Feat/25 feat post 엔티티 category 필드 타입 enum으로 수정, 엔티티 전체 DateTime 수정

### DIFF
--- a/src/main/java/umc/demoday/whatisthis/domain/answer/Answer.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/answer/Answer.java
@@ -2,6 +2,7 @@ package umc.demoday.whatisthis.domain.answer;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
 import umc.demoday.whatisthis.domain.admin.Admin;
 import umc.demoday.whatisthis.domain.inquiry.Inquiry;
 
@@ -24,6 +25,7 @@ public class Answer {
     private String content;
 
     @Column(name = "created_at", nullable = false)
+    @CreatedDate
     private LocalDateTime createdAt;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/umc/demoday/whatisthis/domain/comment/Comment.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/comment/Comment.java
@@ -2,6 +2,8 @@ package umc.demoday.whatisthis.domain.comment;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import umc.demoday.whatisthis.domain.member.Member;
 import umc.demoday.whatisthis.domain.post.Post;
 
@@ -29,9 +31,11 @@ public class Comment {
     private Integer likeCount;
 
     @Column(name = "created_at", nullable = false)
+    @CreatedDate
     private LocalDateTime createdAt;
 
     @Column(name = "updated_at")
+    @LastModifiedDate
     private LocalDateTime updatedAt;
 
     @Column(name = "is_deleted")

--- a/src/main/java/umc/demoday/whatisthis/domain/hashtag/Hashtag.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/hashtag/Hashtag.java
@@ -2,6 +2,7 @@ package umc.demoday.whatisthis.domain.hashtag;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.annotation.LastModifiedDate;
 import umc.demoday.whatisthis.domain.post.Post;
 
 import java.time.LocalDateTime;
@@ -23,6 +24,7 @@ public class Hashtag {
     private String content;
 
     @Column(name = "updated_at")
+    @LastModifiedDate
     private LocalDateTime updatedAt;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/umc/demoday/whatisthis/domain/member/Member.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/member/Member.java
@@ -3,6 +3,7 @@ package umc.demoday.whatisthis.domain.member;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
 import umc.demoday.whatisthis.domain.profile_image.ProfileImage;
 
 import java.time.LocalDateTime;
@@ -32,6 +33,7 @@ public class Member {
     @Column(length = 20)
     private String nickname;
 
+    @CreatedDate
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 

--- a/src/main/java/umc/demoday/whatisthis/domain/notice/Notice.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/notice/Notice.java
@@ -1,6 +1,7 @@
 package umc.demoday.whatisthis.domain.notice;
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
 import umc.demoday.whatisthis.domain.admin.Admin;
 
 import java.time.LocalDateTime;
@@ -25,6 +26,7 @@ public class Notice {
     private String content;
 
     @Column(name = "created_at", nullable = false)
+    @CreatedDate
     private LocalDateTime createdAt;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/umc/demoday/whatisthis/domain/post/Post.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/post/Post.java
@@ -1,6 +1,8 @@
 package umc.demoday.whatisthis.domain.post;
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import umc.demoday.whatisthis.domain.admin.Admin;
 import umc.demoday.whatisthis.domain.member.Member;
 import umc.demoday.whatisthis.domain.post.enums.Category;
@@ -33,9 +35,11 @@ public class Post {
     private Integer likeCount;
 
     @Column(name = "created_at", nullable = false)
+    @CreatedDate
     private LocalDateTime createdAt;
 
     @Column(name = "updated_at")
+    @LastModifiedDate
     private LocalDateTime updatedAt;
 
     @Column(nullable = false, length = 50)

--- a/src/main/java/umc/demoday/whatisthis/domain/post/Post.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/post/Post.java
@@ -3,6 +3,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import umc.demoday.whatisthis.domain.admin.Admin;
 import umc.demoday.whatisthis.domain.member.Member;
+import umc.demoday.whatisthis.domain.post.enums.Category;
 
 import java.time.LocalDateTime;
 
@@ -38,7 +39,8 @@ public class Post {
     private LocalDateTime updatedAt;
 
     @Column(nullable = false, length = 50)
-    private String category;
+    @Enumerated(EnumType.STRING)
+    private Category category;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")

--- a/src/main/java/umc/demoday/whatisthis/domain/post/enums/Category.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/post/enums/Category.java
@@ -1,4 +1,12 @@
 package umc.demoday.whatisthis.domain.post.enums;
 
 public enum Category {
+
+    LIFE_TIP,LIFE_ITEM, // 생활꿀팁, 생활꿀템
+
+    TIP,    // 커뮤니티-생활꿀팁
+    ITEM,   // 커뮤니티-꿀템추천
+    SHOULD_I_BUY,   // 커뮤니티-살까말까?
+    CURIOUS;    // 커뮤니티-궁금해요!
+
 }

--- a/src/main/java/umc/demoday/whatisthis/domain/post/enums/Category.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/post/enums/Category.java
@@ -1,0 +1,4 @@
+package umc.demoday.whatisthis.domain.post.enums;
+
+public enum Category {
+}

--- a/src/main/java/umc/demoday/whatisthis/domain/profile_image/ProfileImage.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/profile_image/ProfileImage.java
@@ -2,6 +2,7 @@ package umc.demoday.whatisthis.domain.profile_image;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.annotation.LastModifiedDate;
 import umc.demoday.whatisthis.domain.member.Member;
 
 import java.time.LocalDateTime;
@@ -20,6 +21,7 @@ public class ProfileImage {
     private Integer id;
 
     @Column(name = "updated_at")
+    @LastModifiedDate
     private LocalDateTime updatedAt;
 
     @Column(name = "image_url", nullable = false, length = 500)

--- a/src/main/java/umc/demoday/whatisthis/domain/qna/Qna.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/qna/Qna.java
@@ -2,6 +2,7 @@ package umc.demoday.whatisthis.domain.qna;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
 import umc.demoday.whatisthis.domain.admin.Admin;
 
 import java.time.LocalDateTime;
@@ -26,6 +27,7 @@ public class Qna {
     private String content;
 
     @Column(name = "created_at", nullable = false)
+    @CreatedDate
     private LocalDateTime createdAt;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/umc/demoday/whatisthis/domain/terms/Terms.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/terms/Terms.java
@@ -2,6 +2,7 @@ package umc.demoday.whatisthis.domain.terms;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
 
 import java.time.LocalDateTime;
 
@@ -28,5 +29,6 @@ public class Terms {
     private String version;
 
     @Column(name = "created_at", nullable = false)
+    @CreatedDate
     private LocalDateTime createdAt;
 }


### PR DESCRIPTION
## PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## 관련 이슈 링크
Close #25 

## 개요
- Post 엔티티 내 category 필드 타입 수정 (String -> ENUM)
- 엔티티 전체 내 created_at, updated_at에 어노테이션 추가

## 변경 사항 (커밋)

## 스크린샷

## 기타 더 이야기해볼 점
agreeAt,searchedAt 등등 시간 관련된 다른 필드들 어떻게 할지

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
