### PR TITLE
Feat/관리자페이지 게시글 수정

### DIFF
--- a/src/main/java/umc/demoday/whatisthis/domain/admin/controller/AdminPostController.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/admin/controller/AdminPostController.java
@@ -1,10 +1,7 @@
 package umc.demoday.whatisthis.domain.admin.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import umc.demoday.whatisthis.domain.admin.dto.AdminPostResDTO;
 import umc.demoday.whatisthis.domain.admin.service.AdminPostService;
 import umc.demoday.whatisthis.global.apiPayload.CustomResponse;
@@ -20,5 +17,11 @@ public class AdminPostController {
     public CustomResponse<AdminPostResDTO> getPost(@PathVariable("post-id") Integer postId){
         AdminPostResDTO response = adminPostService.getPost(postId);
         return CustomResponse.ok(response);
+    }
+
+    @DeleteMapping("/{post-id}")
+    public CustomResponse<Integer> deletePost(@PathVariable("post-id") Integer postId){
+        adminPostService.deletePost(postId);
+        return CustomResponse.ok(postId);
     }
 }

--- a/src/main/java/umc/demoday/whatisthis/domain/admin/controller/AdminPostController.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/admin/controller/AdminPostController.java
@@ -2,6 +2,7 @@ package umc.demoday.whatisthis.domain.admin.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import umc.demoday.whatisthis.domain.admin.dto.AdminPostReqDTO;
 import umc.demoday.whatisthis.domain.admin.dto.AdminPostResDTO;
 import umc.demoday.whatisthis.domain.admin.service.AdminPostService;
 import umc.demoday.whatisthis.global.apiPayload.CustomResponse;
@@ -23,5 +24,11 @@ public class AdminPostController {
     public CustomResponse<Integer> deletePost(@PathVariable("post-id") Integer postId){
         adminPostService.deletePost(postId);
         return CustomResponse.ok(postId);
+    }
+
+    @PatchMapping("/{post-id}")
+    public CustomResponse<AdminPostResDTO.updatePostResDTO> updatePost(@PathVariable("post-id") Integer postId, @RequestBody AdminPostReqDTO.updatePostReqDTO request){
+        AdminPostResDTO.updatePostResDTO response = adminPostService.updatePost(postId, request);
+        return CustomResponse.ok(response);
     }
 }

--- a/src/main/java/umc/demoday/whatisthis/domain/admin/controller/AdminPostController.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/admin/controller/AdminPostController.java
@@ -1,0 +1,24 @@
+package umc.demoday.whatisthis.domain.admin.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import umc.demoday.whatisthis.domain.admin.dto.AdminPostResDTO;
+import umc.demoday.whatisthis.domain.admin.service.AdminPostService;
+import umc.demoday.whatisthis.global.apiPayload.CustomResponse;
+
+@RestController
+@RequestMapping("/admin/posts")
+@RequiredArgsConstructor
+public class AdminPostController {
+
+    private final AdminPostService adminPostService;
+
+    @GetMapping("/{post-id}")
+    public CustomResponse<AdminPostResDTO> getPost(@PathVariable("post-id") Integer postId){
+        AdminPostResDTO response = adminPostService.getPost(postId);
+        return CustomResponse.ok(response);
+    }
+}

--- a/src/main/java/umc/demoday/whatisthis/domain/admin/dto/AdminPostReqDTO.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/admin/dto/AdminPostReqDTO.java
@@ -1,0 +1,24 @@
+package umc.demoday.whatisthis.domain.admin.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import umc.demoday.whatisthis.domain.post.enums.Category;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class AdminPostReqDTO {
+
+    @Getter
+    @Setter
+    @Builder
+    @AllArgsConstructor
+    public static class updatePostReqDTO{
+        String title;
+        String content;
+        Category category;
+        List<String> imageUrls;
+    }
+}

--- a/src/main/java/umc/demoday/whatisthis/domain/admin/dto/AdminPostResDTO.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/admin/dto/AdminPostResDTO.java
@@ -1,6 +1,7 @@
 package umc.demoday.whatisthis.domain.admin.dto;
 
 import lombok.*;
+import umc.demoday.whatisthis.domain.admin.Admin;
 import umc.demoday.whatisthis.domain.post.enums.Category;
 
 import java.time.LocalDateTime;
@@ -20,4 +21,13 @@ public class AdminPostResDTO {
     Integer viewCount;
     Integer scrapCount;
     List<String> imageUrls;
+
+    @Setter
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class updatePostResDTO{
+        Integer postId;
+        LocalDateTime updatedAt;
+    }
 }

--- a/src/main/java/umc/demoday/whatisthis/domain/admin/dto/AdminPostResDTO.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/admin/dto/AdminPostResDTO.java
@@ -28,6 +28,10 @@ public class AdminPostResDTO {
     @AllArgsConstructor
     public static class updatePostResDTO{
         Integer postId;
+        String title;
+        String content;
+        Category category;
+        List<String> imageUrls;
         LocalDateTime updatedAt;
     }
 }

--- a/src/main/java/umc/demoday/whatisthis/domain/admin/dto/AdminPostResDTO.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/admin/dto/AdminPostResDTO.java
@@ -1,0 +1,23 @@
+package umc.demoday.whatisthis.domain.admin.dto;
+
+import lombok.*;
+import umc.demoday.whatisthis.domain.post.enums.Category;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Setter
+@Getter
+@Builder
+@AllArgsConstructor
+public class AdminPostResDTO {
+    Integer postId;
+    String title;
+    String content;
+    Category category;
+    String nickname;
+    LocalDateTime createdAt;
+    Integer viewCount;
+    Integer scrapCount;
+    List<String> imageUrls;
+}

--- a/src/main/java/umc/demoday/whatisthis/domain/admin/service/AdminPostService.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/admin/service/AdminPostService.java
@@ -1,0 +1,55 @@
+package umc.demoday.whatisthis.domain.admin.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import umc.demoday.whatisthis.domain.admin.dto.AdminPostResDTO;
+import umc.demoday.whatisthis.domain.hashtag.Hashtag;
+import umc.demoday.whatisthis.domain.post.Post;
+import umc.demoday.whatisthis.domain.post.enums.Category;
+import umc.demoday.whatisthis.domain.post.repository.PostRepository;
+import umc.demoday.whatisthis.domain.post_image.PostImage;
+import umc.demoday.whatisthis.domain.post_image.repository.PostImageRepository;
+import umc.demoday.whatisthis.domain.post_scrap.repository.PostScrapRepository;
+import umc.demoday.whatisthis.global.apiPayload.code.GeneralErrorCode;
+import umc.demoday.whatisthis.global.apiPayload.exception.GeneralException;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AdminPostService {
+
+    private final PostRepository postRepository;
+    private final PostScrapRepository postScrapRepository;
+
+
+    public AdminPostResDTO getPost(Integer postId) {
+
+        Post post = postRepository.findById(postId).orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND_404));
+
+        //Post.category 기준으로 DTO category(e. g. 생활 꿀팁) 설정
+        Category category = Category.LIFE_ITEM;
+        if(post.getCategory().name().endsWith("_TIP"))
+            category = Category.LIFE_TIP;
+
+        // 이미지 링크들
+        List<String> imageUrls = post.getPostImageList().stream()
+                .map(PostImage::getImageUrl)
+                .toList();
+
+        // 스크랩 수 조회
+        int postScrapCount = postScrapRepository.countByPostId(postId);
+
+        return AdminPostResDTO.builder()
+                .postId(postId)
+                .title(post.getTitle())
+                .content(post.getContent())
+                .category(category)
+                .nickname(post.getMember().getNickname())
+                .createdAt(post.getCreatedAt())
+                .viewCount(post.getViewCount())
+                .scrapCount(postScrapCount)
+                .imageUrls(imageUrls)
+                .build();
+    }
+}

--- a/src/main/java/umc/demoday/whatisthis/domain/admin/service/AdminPostService.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/admin/service/AdminPostService.java
@@ -3,6 +3,7 @@ package umc.demoday.whatisthis.domain.admin.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.demoday.whatisthis.domain.admin.dto.AdminPostReqDTO;
 import umc.demoday.whatisthis.domain.admin.dto.AdminPostResDTO;
 import umc.demoday.whatisthis.domain.hashtag.Hashtag;
 import umc.demoday.whatisthis.domain.post.Post;
@@ -14,7 +15,9 @@ import umc.demoday.whatisthis.domain.post_scrap.repository.PostScrapRepository;
 import umc.demoday.whatisthis.global.apiPayload.code.GeneralErrorCode;
 import umc.demoday.whatisthis.global.apiPayload.exception.GeneralException;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -22,7 +25,7 @@ public class AdminPostService {
 
     private final PostRepository postRepository;
     private final PostScrapRepository postScrapRepository;
-
+    private final PostImageRepository postImageRepository;
 
 
     public AdminPostResDTO getPost(Integer postId) {
@@ -65,5 +68,42 @@ public class AdminPostService {
         postRepository.delete(postToDelete);
 
         return postId;
+    }
+
+    @Transactional
+    public AdminPostResDTO.updatePostResDTO updatePost(Integer postId, AdminPostReqDTO.updatePostReqDTO request) {
+        // 업데이트하려는 게시글이 존재하는지 먼저 확인
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND_404));
+
+        // 존재하면 업데이트
+        if(request.getTitle() != null)
+            post.setTitle(request.getTitle());
+
+        if(request.getContent() != null)
+            post.setContent(request.getContent());
+
+        if(request.getCategory() != null)
+            post.setCategory(request.getCategory());
+
+        // 이미지 정보 업데이트
+        if (request.getImageUrls() != null) {
+            // 기존에 연관된 이미지를 모두 삭제
+            postImageRepository.deleteAllByPost(post);
+
+            // 새로운 이미지 URL 목록으로 PostImage 객체를 생성하고 저장.
+            List<PostImage> newImages = request.getImageUrls().stream()
+                    .map(imageUrl -> PostImage.builder().imageUrl(imageUrl).post(post).build())
+                    .collect(Collectors.toList());
+            postImageRepository.saveAll(newImages);
+
+            // Post 엔티티에도 새로운 이미지 목록을 설정하여 상태를 동기화합니다.
+            post.setPostImageList(newImages);
+        }
+
+        return AdminPostResDTO.updatePostResDTO.builder()
+                .postId(post.getId())
+                .updatedAt(post.getUpdatedAt())
+                .build();
     }
 }

--- a/src/main/java/umc/demoday/whatisthis/domain/admin/service/AdminPostService.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/admin/service/AdminPostService.java
@@ -34,7 +34,7 @@ public class AdminPostService {
 
         //Post.category 기준으로 DTO category(e. g. 생활 꿀팁) 설정
         Category category = Category.LIFE_ITEM;
-        if(post.getCategory().name().endsWith("_TIP"))
+        if (post.getCategory().name().endsWith("_TIP"))
             category = Category.LIFE_TIP;
 
         // 이미지 링크들
@@ -77,13 +77,13 @@ public class AdminPostService {
                 .orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND_404));
 
         // 존재하면 업데이트
-        if(request.getTitle() != null)
+        if (request.getTitle() != null)
             post.setTitle(request.getTitle());
 
-        if(request.getContent() != null)
+        if (request.getContent() != null)
             post.setContent(request.getContent());
 
-        if(request.getCategory() != null)
+        if (request.getCategory() != null)
             post.setCategory(request.getCategory());
 
         // 이미지 정보 업데이트
@@ -100,9 +100,18 @@ public class AdminPostService {
             // Post 엔티티에도 새로운 이미지 목록을 설정하여 상태를 동기화합니다.
             post.setPostImageList(newImages);
         }
+        // 업데이트된 이미지 URL 목록을 가져오기
+        List<String> updatedImageUrls = post.getPostImageList().stream()
+                .map(PostImage::getImageUrl)
+                .collect(Collectors.toList());
 
+        // 모든 필드를 채워서 반환
         return AdminPostResDTO.updatePostResDTO.builder()
                 .postId(post.getId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .category(post.getCategory())
+                .imageUrls(updatedImageUrls)
                 .updatedAt(post.getUpdatedAt())
                 .build();
     }

--- a/src/main/java/umc/demoday/whatisthis/domain/admin/service/AdminPostService.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/admin/service/AdminPostService.java
@@ -2,6 +2,7 @@ package umc.demoday.whatisthis.domain.admin.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import umc.demoday.whatisthis.domain.admin.dto.AdminPostResDTO;
 import umc.demoday.whatisthis.domain.hashtag.Hashtag;
 import umc.demoday.whatisthis.domain.post.Post;
@@ -21,6 +22,7 @@ public class AdminPostService {
 
     private final PostRepository postRepository;
     private final PostScrapRepository postScrapRepository;
+
 
 
     public AdminPostResDTO getPost(Integer postId) {
@@ -51,5 +53,17 @@ public class AdminPostService {
                 .scrapCount(postScrapCount)
                 .imageUrls(imageUrls)
                 .build();
+    }
+
+    @Transactional
+    public Integer deletePost(Integer postId) {
+        // 삭제하려는 게시글이 존재하는지 먼저 확인
+        Post postToDelete = postRepository.findById(postId)
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND_404));
+
+        //존재하면 삭제
+        postRepository.delete(postToDelete);
+
+        return postId;
     }
 }

--- a/src/main/java/umc/demoday/whatisthis/domain/post_image/repository/PostImageRepository.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/post_image/repository/PostImageRepository.java
@@ -12,4 +12,6 @@ public interface PostImageRepository extends JpaRepository<PostImage, Integer> {
     PostImage findOneByPostId(Integer postId);
 
     List<PostImage> findAllByPost_IdIn(List<Integer> postIds);
+
+    void deleteAllByPost(Post post);
 }

--- a/src/test/java/umc/demoday/whatisthis/domain/admin/service/AdminPostServiceTest.java
+++ b/src/test/java/umc/demoday/whatisthis/domain/admin/service/AdminPostServiceTest.java
@@ -1,0 +1,123 @@
+package umc.demoday.whatisthis.domain.admin.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import umc.demoday.whatisthis.domain.admin.dto.AdminPostResDTO;
+import umc.demoday.whatisthis.domain.member.Member;
+import umc.demoday.whatisthis.domain.post.Post;
+import umc.demoday.whatisthis.domain.post.enums.Category;
+import umc.demoday.whatisthis.domain.post.repository.PostRepository;
+import umc.demoday.whatisthis.domain.post_image.PostImage;
+import umc.demoday.whatisthis.domain.post_scrap.repository.PostScrapRepository;
+import umc.demoday.whatisthis.global.apiPayload.code.GeneralErrorCode;
+import umc.demoday.whatisthis.global.apiPayload.exception.GeneralException;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class) // Mockito 확장 기능을 사용합니다.
+class AdminPostServiceTest {
+
+    @InjectMocks // 테스트 대상인 AdminPostService에 Mock 객체들을 주입합니다.
+    private AdminPostService adminPostService;
+
+    @Mock // PostRepository의 Mock 객체를 생성합니다.
+    private PostRepository postRepository;
+
+    @Mock // PostScrapRepository의 Mock 객체를 생성합니다.
+    private PostScrapRepository postScrapRepository;
+
+    @Test
+    @DisplayName("게시글 상세 조회 성공")
+    void 게시글_상세_조회_성공() {
+        // given (테스트 데이터 준비)
+        Integer postId = 1;
+        int scrapCount = 10;
+
+        // 테스트에 사용할 Member, Post, PostImage 객체 생성
+        Member member = Member.builder()
+                .nickname("테스트유저")
+                .build();
+
+        Post post = Post.builder()
+                .id(postId)
+                .title("테스트 제목")
+                .content("테스트 내용")
+                .category(Category.LIFE_TIP)
+                .member(member)
+                .viewCount(100)
+                .build();
+        // Post 객체 내부의 생성 시간 필드를 테스트를 위해 수동으로 설정
+        post.setCreatedAt(LocalDateTime.now());
+
+        PostImage image1 =
+                PostImage.builder()
+                        .imageUrl("http://image.url/1")
+                        .build();
+
+        PostImage image2 =
+                PostImage.builder()
+                        .imageUrl("http://image.url/2")
+                        .build();
+
+        post.setPostImageList(List.of(image1, image2));
+
+
+        // Mock 객체의 동작 정의
+        // postRepository.findById(1)이 호출되면 위에서 만든 post 객체를 Optional로 감싸서 반환
+        given(postRepository.findById(postId)).willReturn(Optional.of(post));
+        // postScrapRepository.countByPostId(1)이 호출되면 10을 반환
+        given(postScrapRepository.countByPostId(postId)).willReturn(scrapCount);
+
+        // when (테스트할 메서드 호출)
+        AdminPostResDTO result = adminPostService.getPost(postId);
+
+        // then (결과 검증)
+        assertThat(result).isNotNull();
+        assertThat(result.getPostId()).isEqualTo(postId);
+        assertThat(result.getTitle()).isEqualTo("테스트 제목");
+        assertThat(result.getNickname()).isEqualTo("테스트유저");
+        assertThat(result.getScrapCount()).isEqualTo(scrapCount);
+        assertThat(result.getViewCount()).isEqualTo(100);
+        assertThat(result.getImageUrls()).hasSize(2);
+        assertThat(result.getImageUrls().get(0)).isEqualTo("http://image.url/1");
+        assertThat(result.getCategory()).isEqualTo(Category.LIFE_TIP); // "_TIP"으로 끝나므로 LIFE_TIP
+
+        // Mock 객체가 예상대로 호출되었는지 검증
+        verify(postRepository).findById(postId);
+        verify(postScrapRepository).countByPostId(postId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 게시글 조회 시 예외 발생")
+    void 존재하지_않는_게시글_조회_실패() {
+        // given (테스트 데이터 준비)
+        Integer nonExistentPostId = 999;
+
+        // postRepository.findById(999)가 호출되면 빈 Optional을 반환하도록 설정
+        given(postRepository.findById(nonExistentPostId)).willReturn(Optional.empty());
+
+        // when & then (예외 발생 검증)
+        // adminPostService.getPost(999)를 호출했을 때 GeneralException이 발생하는지 확인
+        GeneralException exception = assertThrows(GeneralException.class, () -> {
+            adminPostService.getPost(nonExistentPostId);
+        });
+
+        // 발생한 예외의 에러 코드가 NOT_FOUND_404인지 확인
+        assertThat(exception.getCode()).isEqualTo(GeneralErrorCode.NOT_FOUND_404);
+
+        // postScrapRepository.countByPostId는 호출되지 않았는지 검증
+        // verify(postScrapRepository, never()).countByPostId(anyInt());
+    }
+}


### PR DESCRIPTION
## PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## 관련 이슈 링크
Close #62 

## 개요
- Feat/관리자페이지 게시글 수정

## 변경 사항 (커밋)
updatePost 메소드를 컨트롤러와 서비스 클래스에 각각 추가, 
API 명세서에서 response에 postId와 UpdatedAt 뿐 아니라 수정된 모든 내용이 전달되도록 수정.
PostImageRepository에 deleteAllbyPost 메소드 추가
## 스크린샷

## 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
