### PR TITLE
Fix : 모든 Post 불러오기 버그 수정

### DIFF
--- a/src/main/java/umc/demoday/whatisthis/domain/post/dto/PostResponseDTO.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/post/dto/PostResponseDTO.java
@@ -187,9 +187,11 @@ public class PostResponseDTO {
     public static class GgulPostSummaryDTO {
         Integer postId;
         String thumnailUrl;
+        Category category;
+        Category subCategory;
         String title;
         String summary;
-        List<Hashtag> hashtags;
+        List<String> hashtags;
         Integer viewCount;
         Integer likeCount;
         Integer scrapCount;

--- a/src/main/java/umc/demoday/whatisthis/domain/post/enums/SortBy.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/post/enums/SortBy.java
@@ -1,5 +1,5 @@
 package umc.demoday.whatisthis.domain.post.enums;
 
 public enum SortBy {
-    LATEST,BEST;
+    LATEST,BEST,AI;
 }

--- a/src/main/java/umc/demoday/whatisthis/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/post/service/PostServiceImpl.java
@@ -145,6 +145,7 @@ public class PostServiceImpl implements PostService {
             categoryList = Arrays.stream(Category.values())
                     .filter(ct -> ct.name().endsWith("_ITEM"))
                     .toList();
+        else throw new IllegalArgumentException("지원하지 않는 카테고리입니다: " + category);
 
         // 2. Best 정렬 페이지 요청(Pageable) 객체 생성
         Pageable pageableBest = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "likeCount"));
@@ -157,7 +158,7 @@ public class PostServiceImpl implements PostService {
         Page<Post> latestPostPage = postRepository.findByCategoryIn(categoryList, pageableLatest);
 
         //  4. 조회된 Post 엔티티를 MainPageResponseDTO 로 변환
-        return pageConverter.toMainPageResponseDTO(bestPostPage, latestPostPage, categoryList);
+        return pageConverter.toMainPageResponseDTO(bestPostPage, latestPostPage, categoryList, category);
 
     }
 }


### PR DESCRIPTION
## PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## 관련 이슈 링크
Close #97 

## 개요
- JSON이 깨지는 이유는 hashtag와 post의 순환 참조 때문이었습니다

## 변경 사항 (커밋)
- SortBy ENUM에 'AI' 추가
- GgulPostSummaryDTO에 category와 subcategory 추가
## 스크린샷

## 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
