### PR TITLE
[Fix] S3 업로드 가능 용량 제한 변경

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,10 @@ spring:
     properties:
       hibernate:
         format_sql: true
+  servlet:
+    multipart:
+      max-file-size: 10MB      # 최대 파일 1개 크기 (필요에 맞게 조정)
+      max-request-size: 100MB  # 요청 전체 최대 크기 (여러 파일 포함)
 
   data:
     redis:


### PR DESCRIPTION
## PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## 관련 이슈 링크
Close #154 

## 개요
- S3 업로드 가능 용량 제한 변경
-       max-file-size: 10MB      # 최대 파일 1개 크기 (필요에 맞게 조정)
      max-request-size: 100MB  # 요청 전체 최대 크기 (여러 파일 포함)

## 변경 사항 (커밋)
a49be0290b4be3782f7b26425ca9be84a7cd8efd

## 스크린샷

## 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
