### PR TITLE
[Bug] 토큰을 받을 수 있는 경로를 여러개로 설정

### DIFF
--- a/src/main/java/umc/demoday/whatisthis/domain/member/dto/member/PasswordChangeReqDTO.java
+++ b/src/main/java/umc/demoday/whatisthis/domain/member/dto/member/PasswordChangeReqDTO.java
@@ -1,5 +1,6 @@
 package umc.demoday.whatisthis.domain.member.dto.member;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
@@ -8,6 +9,10 @@ import umc.demoday.whatisthis.domain.member.validation.annotation.PasswordMatche
 @PasswordMatches(first = "newPassword", second = "confirmPassword")
 @Getter
 public class PasswordChangeReqDTO {
+
+    // 배포 서버에서는 필요없음 로컬 테스트용
+    @Schema(hidden = true)
+    private String resetToken;
 
     @NotBlank
     @Pattern(


### PR DESCRIPTION
## PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## 관련 이슈 링크
Close #180 

## 개요
- resetToken을 받을 수 있는 경로를 쿠키만에서 헤더, 쿼리, 바디 다 허용
- 이후 배포시에는 원래대로 바꿔놓으면 됨 (지금도 작동은 함, 코드가 더러워서 그렇지)

## 변경 사항 (커밋)

## 스크린샷

## 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
